### PR TITLE
Update to use the latest chart 1.0.3 and for image version 1.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # cloud-platform-terraform-cluster-autoscaler
 
-[![Releases](https://img.shields.io/github/release/ministryofjustice/cloud-platform-terraform-template/all.svg?style=flat-square)](https://github.com/ministryofjustice/cloud-platform-terraform-template/releases)
+[![Releases](https://img.shields.io/github/release/ministryofjustice/cloud-platform-terraform-cluster-autoscaler/all.svg?style=flat-square)](https://github.com/ministryofjustice/cloud-platform-terraform-cluster-autoscaler/releases)
 
 This is the cluster-autoscaler terraform module
 

--- a/main.tf
+++ b/main.tf
@@ -29,7 +29,7 @@ module "iam_assumable_role_admin" {
   role_name                     = "cas.${var.cluster_domain_name}"
   provider_url                  = var.eks_cluster_oidc_issuer_url
   role_policy_arns              = [ length(aws_iam_policy.cluster_autoscaler) >= 1 ? aws_iam_policy.cluster_autoscaler.0.arn : ""]
-  oidc_fully_qualified_subjects = ["system:serviceaccount:kube-system:cluster-autoscaler-aws-cluster-autoscaler"]
+  oidc_fully_qualified_subjects = ["system:serviceaccount:kube-system:cluster-autoscaler"]
 }
 
 resource "aws_iam_policy" "cluster_autoscaler" {

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 
 data "helm_repository" "stable" {
-  name = "stable"
-  url  = "https://kubernetes-charts.storage.googleapis.com"
+  name = "autoscaler"
+  url  = "https://kubernetes.github.io/autoscaler"
 }
 
 resource "helm_release" "cluster_autoscaler" {
@@ -9,10 +9,10 @@ resource "helm_release" "cluster_autoscaler" {
 
   name       = "cluster-autoscaler"
   repository = data.helm_repository.stable.metadata[0].name
-  chart      = "cluster-autoscaler"
+  chart      = "cluster-autoscaler-chart"
 
   namespace = "kube-system"
-  version   = "6.2.0"
+  version   = "1.0.3"
 
   values = [templatefile("${path.module}/templates/cluster-autoscaler.yaml.tpl", {
     cluster_name        = terraform.workspace

--- a/templates/cluster-autoscaler.yaml.tpl
+++ b/templates/cluster-autoscaler.yaml.tpl
@@ -13,6 +13,7 @@ autoDiscovery:
 
 rbac:
   create: true
+  pspEnabled: true
   serviceAccount:
     create: true
     name: cluster-autoscaler

--- a/templates/cluster-autoscaler.yaml.tpl
+++ b/templates/cluster-autoscaler.yaml.tpl
@@ -1,7 +1,3 @@
-rbac:
-  create: true
-
-# sslCertPath: /etc/ssl/certs/ca-bundle.crt
 
 cloudProvider: aws
 awsRegion: eu-west-2
@@ -10,11 +6,10 @@ image:
   # image.repository -- Image repository
   repository: us.gcr.io/k8s-artifacts-prod/autoscaling/cluster-autoscaler
   # image.tag -- Image tag
-  tag: v1.17.3
+  tag: v1.16.6
 
 autoDiscovery:
   clusterName: ${cluster_name}
-  # enabled: true
 
 rbac:
   create: true

--- a/templates/cluster-autoscaler.yaml.tpl
+++ b/templates/cluster-autoscaler.yaml.tpl
@@ -1,20 +1,27 @@
 rbac:
   create: true
 
-sslCertPath: /etc/ssl/certs/ca-bundle.crt
+# sslCertPath: /etc/ssl/certs/ca-bundle.crt
 
 cloudProvider: aws
 awsRegion: eu-west-2
 
+image:
+  # image.repository -- Image repository
+  repository: us.gcr.io/k8s-artifacts-prod/autoscaling/cluster-autoscaler
+  # image.tag -- Image tag
+  tag: v1.17.3
+
 autoDiscovery:
   clusterName: ${cluster_name}
-  enabled: true
+  # enabled: true
 
 rbac:
   create: true
   serviceAccount:
     create: true
     name: cluster-autoscaler
+    annotations:
+      eks.amazonaws.com/role-arn: "${eks_service_account}" 
+  
 
-  serviceAccountAnnotations:
-    eks.amazonaws.com/role-arn: "${eks_service_account}" 


### PR DESCRIPTION
The existing chart is deprecated and latest chart is moved to https://github.com/kubernetes/autoscaler/tree/master/charts/cluster-autoscaler-chart

This PR is to update the chart to the latest and with new image us.gcr.io/k8s-artifacts-prod/autoscaling/cluster-autoscaler 
with image tag 1.16.6