### PR TITLE
set overprovision cpu request to 2m

### DIFF
--- a/overprovision.tf
+++ b/overprovision.tf
@@ -11,10 +11,10 @@ locals {
   }
 
   pod_cpu = {
-    manager = "100m"
-    live    = "100m"
-    live-2  = "100m"
-    default = "100m"
+    manager = "2m"
+    live    = "2m"
+    live-2  = "2m"
+    default = "2m"
   }
 }
 


### PR DESCRIPTION
current `live` utilisation is hovering around 0.0002 - ~ 0.001** cores