### PR TITLE
add parameter in values to ignore daemonsets utilisation

### DIFF
--- a/templates/cluster-autoscaler.yaml.tpl
+++ b/templates/cluster-autoscaler.yaml.tpl
@@ -16,6 +16,7 @@ extraArgs:
   stderrthreshold: info
   v: 4
   scale-down-utilization-threshold: 0.1
+  ignore-daemonsets-utilization: true
 
 rbac:
   create: true


### PR DESCRIPTION
This PR configures autoscaler to ignore daemonset request values in scale-down calculation.

https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#how-does-scale-down-work
