### PR TITLE
fix: 🐛 psp:restricted->psp:0-super-priviileged

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ module "cluster_autoscaler" {
 | [helm_release.cluster-proportional-autoscaler-cpu](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.cluster-proportional-autoscaler-memory](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.cluster_autoscaler](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
+| [kubernetes_cluster_role_binding.super_privileged](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/cluster_role_binding) | resource |
 | [kubernetes_namespace.overprovision](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace) | resource |
 | [aws_iam_policy_document.cluster_autoscaler](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 

--- a/main.tf
+++ b/main.tf
@@ -77,3 +77,19 @@ data "aws_iam_policy_document" "cluster_autoscaler" {
     }
   }
 }
+
+resource "kubernetes_cluster_role_binding" "super_privileged" {
+  metadata {
+    name = "default:0-super-privileged"
+  }
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "ClusterRole"
+    name      = "psp:0-super-privileged"
+  }
+  subject {
+    kind      = "ServiceAccount"
+    name      = "cluster-autoscaler"
+    namespace = "kube-system"
+  }
+}


### PR DESCRIPTION
for cluster-autoscaler

Following removal of custom psps cluster-autoscaler is adopting the incorrect value of `psp:restricted`