### PR TITLE
upgrade cluster autoscaler for 1.26

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,7 @@ resource "helm_release" "cluster_autoscaler" {
   chart      = "cluster-autoscaler"
 
   namespace = "kube-system"
-  version   = "9.28.0"
+  version   = "9.35.0"
 
   values = [templatefile("${path.module}/templates/cluster-autoscaler.yaml.tpl", {
     cluster_name        = terraform.workspace

--- a/overprovision.tf
+++ b/overprovision.tf
@@ -75,7 +75,7 @@ resource "helm_release" "cluster-proportional-autoscaler-cpu" {
   chart      = "cluster-proportional-autoscaler"
   namespace  = kubernetes_namespace.overprovision[count.index].id
   repository = "https://kubernetes-sigs.github.io/cluster-proportional-autoscaler"
-  version    = "1.0.1"
+  version    = "1.1.0"
 
   values = [templatefile("${path.module}/templates/cpa-cpu.yaml.tpl", {
   })]

--- a/templates/cluster-autoscaler.yaml.tpl
+++ b/templates/cluster-autoscaler.yaml.tpl
@@ -6,7 +6,7 @@ image:
   # image.repository -- Image repository
   repository: registry.k8s.io/autoscaling/cluster-autoscaler
   # image.tag -- Image tag
-  tag: v1.25.3
+  tag: v1.26.6
 
 autoDiscovery:
   clusterName: ${cluster_name}


### PR DESCRIPTION
- Upgrade cluster autoscaler chart and set image to 1.26.6. The helm chart is upgraded to latest available. But the image is matched to the cluster version 1.26.x as per the release matrix. https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler#releases
All helm charts versions are compatible with 
- Upgrade proportional-cpu to 1.1.0
Related to: https://github.com/ministryofjustice/cloud-platform/issues/5279
