### PR TITLE
Add eks:DescribeNodegroup to fix Failed to query the managed nodegroup

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -60,6 +60,7 @@ data "aws_iam_policy_document" "cluster_autoscaler" {
       "autoscaling:SetDesiredCapacity",
       "autoscaling:TerminateInstanceInAutoScalingGroup",
       "autoscaling:UpdateAutoScalingGroup",
+      "eks:DescribeNodegroup",
     ]
 
     resources = ["*"]


### PR DESCRIPTION
Related to: https://github.com/ministryofjustice/cloud-platform/issues/5367