### PR TITLE
Move ec2, eks permissions to all resources

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -42,6 +42,8 @@ data "aws_iam_policy_document" "cluster_autoscaler" {
       "autoscaling:DescribeTags",
       "ec2:DescribeLaunchTemplateVersions",
       "ec2:DescribeInstanceTypes",
+      "ec2:DescribeLaunchTemplateVersions",
+      "eks:DescribeNodegroup",
     ]
 
     resources = ["*"]
@@ -56,11 +58,9 @@ data "aws_iam_policy_document" "cluster_autoscaler" {
       "autoscaling:DescribeAutoScalingInstances",
       "autoscaling:DescribeLaunchConfigurations",
       "autoscaling:DescribeTags",
-      "ec2:DescribeLaunchTemplateVersions",
       "autoscaling:SetDesiredCapacity",
       "autoscaling:TerminateInstanceInAutoScalingGroup",
       "autoscaling:UpdateAutoScalingGroup",
-      "eks:DescribeNodegroup",
     ]
 
     resources = ["*"]


### PR DESCRIPTION
These permissions cant be given to tags which are specific for autocaling and can only be given to all eks and ec2 resources