### PR TITLE
Upgrade cluster autoscaler to use 1.27

### DIFF
--- a/templates/cluster-autoscaler.yaml.tpl
+++ b/templates/cluster-autoscaler.yaml.tpl
@@ -6,7 +6,7 @@ image:
   # image.repository -- Image repository
   repository: registry.k8s.io/autoscaling/cluster-autoscaler
   # image.tag -- Image tag
-  tag: v1.26.6
+  tag: v1.27.5
 
 autoDiscovery:
   clusterName: ${cluster_name}


### PR DESCRIPTION
The cloud platform cluster is upgrade to 1.27. Upgrade cluster autoscaler to match the k8s version

Related to: https://github.com/ministryofjustice/cloud-platform/issues/5353
