### PR TITLE
Upgrade autoscaler to correct version for kube 1.30

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,7 @@ resource "helm_release" "cluster_autoscaler" {
   chart      = "cluster-autoscaler"
 
   namespace = "kube-system"
-  version   = "9.35.0"
+  version   = "9.37.0"
 
   values = [templatefile("${path.module}/templates/cluster-autoscaler.yaml.tpl", {
     cluster_name        = terraform.workspace


### PR DESCRIPTION
Upgrading autoscaler to correct version for kube 1.30 post upgrade - [#6720](https://github.com/ministryofjustice/cloud-platform/issues/6720)