### PR TITLE
Vpa recommender

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ module "cluster_autoscaler" {
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2.5 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >=3.0.0 |
-| <a name="requirement_helm"></a> [helm](#requirement\_helm) | >=2.6.0 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | >=3.0.2 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >=2.12.1 |
 
 ## Providers
@@ -33,7 +33,7 @@ module "cluster_autoscaler" {
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >=3.0.0 |
-| <a name="provider_helm"></a> [helm](#provider\_helm) | >=2.6.0 |
+| <a name="provider_helm"></a> [helm](#provider\_helm) | >=3.0.2 |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >=2.12.1 |
 
 ## Modules
@@ -51,6 +51,7 @@ module "cluster_autoscaler" {
 | [helm_release.cluster-proportional-autoscaler-cpu](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.cluster-proportional-autoscaler-memory](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.cluster_autoscaler](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
+| [helm_release.vpa](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [kubernetes_namespace.overprovision](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace) | resource |
 | [aws_iam_policy_document.cluster_autoscaler](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
@@ -62,6 +63,7 @@ module "cluster_autoscaler" {
 | <a name="input_eks_cluster_id"></a> [eks\_cluster\_id](#input\_eks\_cluster\_id) | The EKS cluster ID used by the autoscaler | `any` | n/a | yes |
 | <a name="input_eks_cluster_oidc_issuer_url"></a> [eks\_cluster\_oidc\_issuer\_url](#input\_eks\_cluster\_oidc\_issuer\_url) | If EKS variable is set to true this is going to be used when we create the IAM OIDC role | `string` | `""` | no |
 | <a name="input_enable_overprovision"></a> [enable\_overprovision](#input\_enable\_overprovision) | Enable or disbale creation of overprovisioner | `bool` | `true` | no |
+| <a name="input_enable_vpa_recommender"></a> [enable\_vpa\_recommender](#input\_enable\_vpa\_recommender) | Enable or disable creation of VPA recommender-only deployment | `bool` | `false` | no |
 | <a name="input_live_cpu_request"></a> [live\_cpu\_request](#input\_live\_cpu\_request) | Overprovisioner cpu request for live pods | `string` | `"200m"` | no |
 | <a name="input_live_memory_request"></a> [live\_memory\_request](#input\_live\_memory\_request) | Overprovisioner memory request for live pods | `string` | `"1800Mi"` | no |
 

--- a/variables.tf
+++ b/variables.tf
@@ -29,3 +29,9 @@ variable "live_cpu_request" {
   type        = string
   default     = "200m"
 }
+
+variable "enable_vpa_recommender" {
+  description = "Enable or disable creation of VPA recommender-only deployment"
+  type        = bool
+  default     = false
+}

--- a/versions.tf
+++ b/versions.tf
@@ -7,7 +7,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">=2.6.0"
+      version = ">=3.0.2"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/vpa.tf
+++ b/vpa.tf
@@ -1,0 +1,23 @@
+
+resource "helm_release" "vpa" {
+  count      = var.enable_vpa_recommender ? 1 : 0
+  name       = "vpa"
+  repository = "https://charts.fairwinds.com/stable"
+  chart      = "vpa"
+  version    = "4.8.1"
+  namespace  = "kube-system"
+  create_namespace = false
+
+  set {
+    name  = "recommender.enabled"
+    value = "true"
+  }
+  set {
+    name  = "updater.enabled"
+    value = "false"
+  }
+  set {
+    name  = "admissionController.enabled"
+    value = "false"
+  }
+}

--- a/vpa.tf
+++ b/vpa.tf
@@ -8,16 +8,21 @@ resource "helm_release" "vpa" {
   namespace  = "kube-system"
   create_namespace = false
 
-  set {
-    name  = "recommender.enabled"
-    value = "true"
-  }
-  set {
-    name  = "updater.enabled"
-    value = "false"
-  }
-  set {
-    name  = "admissionController.enabled"
-    value = "false"
-  }
+  set = [
+    {
+      name  = "recommender.enabled"
+      value = "true"
+    },
+    {
+      name  = "updater.enabled"
+      value = "false"
+    },
+    {
+      name  = "admissionController.enabled"
+      value = "false"
+    }
+  ]
 }
+
+
+


### PR DESCRIPTION
## Purpose

This PR adds the Fairwinds VPA Helm chart with configuration set to `Recommender` mode

https://github.com/FairwindsOps/charts/tree/master/stable/vpa#vpa

https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler#vertical-pod-autoscaler

- helm_release
- vpa deploy toggle variable
- bump helm provider version to match infra `core`
