### PR TITLE
post eks bump

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,7 @@ resource "helm_release" "cluster_autoscaler" {
   chart      = "cluster-autoscaler"
 
   namespace = "kube-system"
-  version   = "9.51.0"
+  version   = "9.52.0"
 
   values = [templatefile("${path.module}/templates/cluster-autoscaler.yaml.tpl", {
     cluster_name        = terraform.workspace


### PR DESCRIPTION
Upgrade cluster autoscaler for EKS version 1.34 post upgrade as per this issue https://github.com/orgs/ministryofjustice/projects/65/views/43?pane=issue&itemId=207736570&issue=ministryofjustice%7Ccloud-platform%7C8358